### PR TITLE
Add custom sidepanel

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -1,5 +1,8 @@
 import Mirador from 'mirador';
-import { jhAnnotationFetchPlugin } from '../../src';
+import { 
+  jhAnnotationFetchPlugin,
+  jhAnnotationsPanelPlugin
+} from '../../src';
 
 const config = {
   id: 'demo',
@@ -39,7 +42,8 @@ const config = {
 };
 
 const plugins = [
-  jhAnnotationFetchPlugin
+  jhAnnotationFetchPlugin,
+  jhAnnotationsPanelPlugin
 ];
 
 const miradorInstance = Mirador.viewer(config, plugins);

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
 export jhAnnotationFetchPlugin from './plugins/jh-annotation-fetch-plugin/plugin';
+export jhAnnotationsPanelPlugin from './plugins/jh-annotations-panel/plugin';

--- a/src/plugins/jh-annotations-panel/README.md
+++ b/src/plugins/jh-annotations-panel/README.md
@@ -1,0 +1,7 @@
+This plugin replaces the original [WindowSideBarAnnotationsPanel](https://github.com/ProjectMirador/mirador/blob/master/src/components/WindowSideBarAnnotationsPanel.js) component, used to display annotations in the sidebar of a window.
+
+### Motivation
+
+Simply put, our project does things a bit differently from the way Mirador 3 has been designed. We have annotations from several different data sources for select manifests. On top of that we desire much more custom behavior to some of these annotations. On top of all this, all of our annotations follow the Web Annotation data model, as opposed to the standard IIIF annotation data model. Our web annotations have features, such as multiple bodies, that are not strictly supported by IIIF 3.
+
+

--- a/src/plugins/jh-annotations-panel/container.js
+++ b/src/plugins/jh-annotations-panel/container.js
@@ -1,10 +1,61 @@
 import { getAnnotationResourcesByMotivation } from 'mirador/dist/es/src/state/selectors/annotations';
 import { getVisibleCanvases } from 'mirador/dist/es/src/state/selectors/canvases';
+import flatten from 'lodash/flatten';
+
+/**
+ * This is mostly a trial for a custom selector to get a feel for how they work and interact with this plugin.
+ * This particular function will return all AnnotationPages or Annotationlists for the currently visible
+ * canvases.
+ * 
+ * @param {object} state Mirador's application state
+ * @param {array} canvases array of Canvas JSON objs
+ */
+function getAnnotationsForVisibleCanvases(state, canvases) {
+  const { annotations } = state;
+  // Fail fast if no canvases were provided
+  if (!canvases || !(Array.isArray(canvases) && canvases.length > 0)) {
+    return [];
+  }
+  // Fail fast if no annotations are found in the application state
+  if (!annotations) {
+    return [];
+  }
+
+  /*
+   * This part takes a bit more explanation (for me, at least)
+   * 'annotations' is essentially a map of Canvas IDs to ... another map. The 2nd map indexes annotation page
+   * IDs to AnnotationPage objects. Here is a simplified example to illustrate:
+   * 
+   *  annotations: {
+   *    'canvas-1': {
+   *      'annoPage1': { id: 'annoPage1', json: { ... } },
+   *      'annoPage2': { id: 'annoPage2', json: { ... } }
+   *    },
+   *    'canvas-2': {
+   *      'annoPage3': { id: 'annoPage3', json: { ... } }
+   *    }
+   *  }
+   * 
+   * So this part will resolve the first level map (the 'canvas-1' level objects above) with the given canvas IDs from 
+   * the 'canvases' param (Object.values). The canvas objects in the 'canvases' param are mapped to the resolved first 
+   * level map. So now you have an array of the values of the first level map. This is finally flattened to give a 
+   * single tier array of the "annotation page" objects.
+   */
+  const annoPages = flatten(
+    canvases.map(canvas => Object.values(annotations[canvas.id]))
+  );
+  debugger
+  return annoPages;
+}
 
 export const mapStateToProps = (state, props) => {
+  const selectedCanvases = getVisibleCanvases(state, { windowId: props.targetProps.windowId });
+  const presentAnnotations = getAnnotationsForVisibleCanvases(state, selectedCanvases);
+
   return ({
     annotationCount: getAnnotationResourcesByMotivation(state, { motivations: ['oa:commenting', 'sc:painting', 'commenting'], windowId: props.targetProps.windowId }).length,
-    selectedCanvases: getVisibleCanvases(state, { windowId: props.targetProps.windowId }),
+    selectedCanvases,
+    presentAnnotations
   })
 };
 

--- a/src/plugins/jh-annotations-panel/container.js
+++ b/src/plugins/jh-annotations-panel/container.js
@@ -1,0 +1,21 @@
+import { getAnnotationResourcesByMotivation } from 'mirador/dist/es/src/state/selectors/annotations';
+import { getVisibleCanvases } from 'mirador/dist/es/src/state/selectors/canvases';
+
+export const mapStateToProps = (state, props) => {
+  return ({
+    annotationCount: getAnnotationResourcesByMotivation(state, { motivations: ['oa:commenting', 'sc:painting', 'commenting'], windowId: props.targetProps.windowId }).length,
+    selectedCanvases: getVisibleCanvases(state, { windowId: props.targetProps.windowId }),
+  })
+};
+
+export const mapDispatchToProps = {};
+// const styles = theme => ({
+//   section: {
+//     borderBottom: `.5px solid ${theme.palette.section_divider}`,
+//     paddingBottom: theme.spacing(1),
+//     paddingLeft: theme.spacing(2),
+//     paddingRight: theme.spacing(1),
+//     paddingTop: theme.spacing(2),
+//   },
+// });
+

--- a/src/plugins/jh-annotations-panel/jh-annotations-panel.js
+++ b/src/plugins/jh-annotations-panel/jh-annotations-panel.js
@@ -1,0 +1,46 @@
+import React, { Component } from 'react';
+import Typography from '@material-ui/core/Typography';
+import AnnotationSettings from 'mirador/dist/es/src/containers/AnnotationSettings';
+import CanvasAnnotations from 'mirador/dist/es/src/containers/CanvasAnnotations';
+import CompanionWindow from 'mirador/dist/es/src/containers/CompanionWindow';
+import ns from 'mirador/dist/es/src/config/css-ns';
+
+/**
+ * WindowSideBarAnnotationsPanel ~
+*/
+export default class JHAnnotationsPanel extends Component {
+  /**
+   * Returns the rendered component
+  */
+  render() {
+    const {
+      annotationCount, classes, selectedCanvases, t, windowId, id,
+    } = this.props.targetProps;
+
+    return (
+      <CompanionWindow
+        title={t('annotations')}
+        paperClassName={ns('window-sidebar-annotation-panel')}
+        windowId={windowId}
+        id={id}
+        titleControls={<AnnotationSettings windowId={windowId} />}
+      >
+        <div className={classes.section}>
+          <h1>Custom Annotations Sidebar Panel!</h1>
+          <Typography component="p" variant="subtitle2">{t('showingNumAnnotations', { number: annotationCount })}</Typography>
+        </div>
+
+        {selectedCanvases.map((canvas, index) => (
+          <CanvasAnnotations
+            canvasId={canvas.id}
+            key={canvas.id}
+            index={index}
+            totalSize={selectedCanvases.length}
+            windowId={windowId}
+          />
+        ))}
+      </CompanionWindow>
+    );
+  }
+}
+

--- a/src/plugins/jh-annotations-panel/plugin.js
+++ b/src/plugins/jh-annotations-panel/plugin.js
@@ -1,0 +1,14 @@
+import JHAnnotationsPanel from './jh-annotations-panel';
+import { mapStateToProps, mapDispatchToProps } from './container';
+
+/**
+ * Plugin definition used by Mirador
+ */
+export default {
+  name: 'JHAnnotationsPanelPlugin',
+  target: 'WindowSideBarAnnotationPanel',
+  mode: 'wrap',
+  component: JHAnnotationsPanel,
+  mapStateToProps,
+  mapDispatchToProps
+};


### PR DESCRIPTION
Early example of a custom Annotations panel to replace the built-in annotations panel that comes with Mirador