### PR TITLE
Styling updates for custom annotation panel

### DIFF
--- a/src/plugins/jh-annotations-panel/components/annotation.js
+++ b/src/plugins/jh-annotations-panel/components/annotation.js
@@ -3,7 +3,7 @@ import AnnotationBody from './annotationBody';
 
 /**
  * Should display an annotation, possibly decorated by other annotations
- * 
+ *
  * props: {
  *    annotation: { ... }, // The subject of this component
  *    targetedBy: [
@@ -12,13 +12,14 @@ import AnnotationBody from './annotationBody';
  *  }
  */
 export default class Annotation extends Component {
-
   render() {
     const { annotation } = this.props;
 
     // The annotation has content if 'annotation.body' is an array with 1 or more elements,
     // or is not an array and exists
-    const hasContent = Array.isArray(annotation.body) ? annotation.body.length > 0 : !!annotation.body;
+    const hasContent = Array.isArray(annotation.body)
+      ? annotation.body.length > 0
+      : !!annotation.body;
 
     // If no content is detected, return early
     if (!hasContent) {
@@ -32,23 +33,30 @@ export default class Annotation extends Component {
     let creator;
     if (annotation.creator) {
       if (typeof annotation.creator === 'string') {
-        creator = (<><span>Creator: </span><a href={annotation.creator} target="_blank">{annotation.creator}</a></>);
+        creator = (
+          <>
+            <span style={{ fontStyle: 'italic' }}>Creator: </span>
+            <a href={annotation.creator} target='_blank'>
+              {annotation.creator}
+            </a>
+          </>
+        );
       } else if (typeof annotation.creator === 'object') {
-        creator = (<a href={annotation.creator.id} target="_blank">{annotation.creator.name}</a>);
+        creator = (
+          <a href={annotation.creator.id} target='_blank'>
+            {annotation.creator.name}
+          </a>
+        );
       }
     } else {
       creator = <></>;
     }
-    
+
     return (
-      <div className="annotation">
-        <div className="annotation-label">Label: {annotation.label}</div>
-        <div className="annotation-bodies">
-          {bodies}
-        </div>
-        <div className="annotation-creator">
-          {creator}
-        </div>
+      <div className='annotation'>
+        <div className='annotation-label'>{annotation.label}</div>
+        <div className='annotation-bodies'>{bodies}</div>
+        <div className='annotation-creator'>{creator}</div>
       </div>
     );
   }

--- a/src/plugins/jh-annotations-panel/components/annotationBody.js
+++ b/src/plugins/jh-annotations-panel/components/annotationBody.js
@@ -4,10 +4,10 @@ import React, { Component } from 'react';
  * Render an annotation body. Specifics of how it is rendered may
  * depend on the properties of the annotation body, such as type,
  * format, etc
- * 
+ *
  * We could break out different annotation 'purposes' into separate
  * components if we think it would help.
- * 
+ *
  * props: {
  *    body: { ... }
  *  }
@@ -20,26 +20,29 @@ export default class AnnotationBody extends Component {
 
     if (body.purpose === 'tagging') {
       content = (
-        <div>Tag: {body.value}</div>
+        <>
+          <div style={{ fontStyle: 'italic' }}>Tag: </div>
+          <div style={{ textIndent: '8px' }}>{body.value}</div>
+        </>
       );
     } else if (body.purpose === 'commenting') {
       content = (
-        <div>(comment: {body.value})</div>
+        <>
+          <div style={{ fontStyle: 'italic' }}>Comment: </div>
+          <div style={{ textIndent: '8px' }}>{body.value}</div>
+        </>
       );
     } else if (body.purpose === 'identifying') {
       content = (
         <div>
-          <a href={body.source} target="_blank">{body.source}</a>
+          <a href={body.source} target='_blank'>
+            {body.source}
+          </a>
         </div>
       );
     } else {
-
     }
 
-    return (
-      <div className="annotation-body">
-        {content}
-      </div>
-    );
+    return <div className='annotation-body'>{content}</div>;
   }
 }


### PR DESCRIPTION
Addresses https://github.com/jhu-digital-manuscripts/AnIOp/issues/81

- Removed 'label' string; Italicized annotation part labels
- Tab indent annotation part values
- Annotation part values on newline

![image](https://user-images.githubusercontent.com/4250470/81195790-4d1a8b00-8f8c-11ea-92cc-fec632a26b84.png)

Note: I use the `Prettier` extension in VsCode for code formatting