### PR TITLE
Remove ThemeProvider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14484,6 +14484,11 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typeface-roboto": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/typeface-roboto/-/typeface-roboto-0.0.75.tgz",
+      "integrity": "sha512-VrR/IiH00Z1tFP4vDGfwZ1esNqTiDMchBEXYY9kilT6wRGgFoCAlgkEUMHb1E3mB0FsfZhv756IF0+R+SFPfdg=="
+    },
     "ua-parser-js": {
       "version": "0.7.21",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.9.9",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "typeface-roboto": "0.0.75"
   },
   "devDependencies": {
     "eslint": "6.8.0",

--- a/src/plugins/jh-annotations-panel/jh-annotations-panel.js
+++ b/src/plugins/jh-annotations-panel/jh-annotations-panel.js
@@ -5,34 +5,32 @@ import CanvasAnnotations from 'mirador/dist/es/src/containers/CanvasAnnotations'
 import CompanionWindow from 'mirador/dist/es/src/containers/CompanionWindow';
 import ns from 'mirador/dist/es/src/config/css-ns';
 import AnnotationPage from './components/annotationPage';
-import { createMuiTheme } from '@material-ui/core/styles';
-import { ThemeProvider } from '@material-ui/core/styles';
 import { CssBaseline } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
+import 'typeface-roboto';
 
-const panelTheme = createMuiTheme({
-  typography: {
-    fontFamily: [
-      'Roboto',
-    ],
-  },
-});
+require('typeface-roboto');
 
 /**
  * WindowSideBarAnnotationsPanel ~
-*/
+ */
 export default class JHAnnotationsPanel extends Component {
   /**
    * Returns the rendered component
-  */
+   */
   render() {
     const { classes, t, windowId, id } = this.props.targetProps;
-    const { annotationCount, selectedCanvases, presentAnnotations, canvasLabels } = this.props;
+    const {
+      annotationCount,
+      selectedCanvases,
+      presentAnnotations,
+      canvasLabels,
+    } = this.props;
 
     const annoPages = presentAnnotations.map((annoPage, index) => {
       if (annoPage.json['@type'] === 'sc:AnnotationList') {
         // Ignore old-style annotation lists for now
-        return <div className="hidden" key={annoPage.id}></div>;
+        return <div className='hidden' key={annoPage.id}></div>;
       }
 
       return (
@@ -58,9 +56,9 @@ export default class JHAnnotationsPanel extends Component {
     ));
 
     return (
-      <ThemeProvider>
-        <CssBaseline>
-          {<CompanionWindow
+      <CssBaseline>
+        {
+          <CompanionWindow
             title={t('annotations')}
             paperClassName={ns('window-sidebar-annotation-panel')}
             windowId={windowId}
@@ -68,23 +66,19 @@ export default class JHAnnotationsPanel extends Component {
             titleControls={<AnnotationSettings windowId={windowId} />}
           >
             <div className={classes.section}>
-              <Typography component="p" variant="subtitle2">{t('showingNumAnnotations', { number: annotationCount })}</Typography>
+              <Typography component='p' variant='subtitle2'>
+                {t('showingNumAnnotations', { number: annotationCount })}
+              </Typography>
             </div>
 
-            <div>
-              {miradorAnnos}
-            </div>
+            <div>{miradorAnnos}</div>
 
-            <Box pl="8px" pr="8px">
-              <div>
-                {annoPages}
-              </div>
+            <Box pl='8px' pr='8px'>
+              <div>{annoPages}</div>
             </Box>
-
-          </CompanionWindow>}
-        </CssBaseline>
-      </ThemeProvider>
+          </CompanionWindow>
+        }
+      </CssBaseline>
     );
   }
 }
-


### PR DESCRIPTION
We were using ThemeProvider to provide the Roboto font to our plugin - this is incorrect, especially because ThemeProvider requires a theme to be passed to it, and we were not doing that. This resulted in some crashes. We are now doing the correct approach of installing the Robot font and requiring it at our plugin entry point.