### PR TITLE
Update what pages are loaded in the viewer by default

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -5,15 +5,15 @@ const config = {
   id: 'demo',
   windows: [
     {
-      loadedManifest:
-        'https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/manifest',
-      canvasId:
-        'https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA035RN-0036/canvas',
+      loadedManifest: 'https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/manifest',
+      canvasId: 'https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA035RN-0036/canvas',
+      view: 'single'
     },
     {
-      loadedManifest:
-        'https://rosetest.library.jhu.edu/rosademo/iiif/rose/SeldenSupra57/manifest',
-    },
+      loadedManifest: 'https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/manifest',
+      canvasId: 'https://rosetest.library.jhu.edu/rosademo/iiif/homer/VA/VA012RN-0013/canvas',
+      view: 'single'
+    }
   ],
   window: {
     defaultView: 'single',


### PR DESCRIPTION
* No longer show SeldenSupra MS on initial load
* Load folio 35r and 12r by default
* Show single page, instead of opening

These pages were chosen to separately showcase georeference annotations and other named entity annotations