### PR TITLE
Fix finding Homer discovery service

### DIFF
--- a/src/plugins/jh-annotation-fetch-plugin/EldarionAnnotationService.js
+++ b/src/plugins/jh-annotation-fetch-plugin/EldarionAnnotationService.js
@@ -30,7 +30,15 @@ export function getEldarionAnnotations(canvases, receiveAnnotation, manifest) {
      * New section will try a known URL to reach the trial discovery service in order to
      * get annotation endpoints
      */
-    const discoveryUrl = getEDS(manifest) || 'https://aniop-atlas-staging.eldarion.com/wa/discovery/';
+    const discoveryUrl = getEDS(manifest);
+
+    /**
+     * Don't do anything if no discovery service was found
+     */
+    if (!discoveryUrl) {
+      return;
+    }
+
     const target = `${discoveryUrl}?canvas_id=${canvasId}`;
 
     fetch(target, { method: 'GET' })
@@ -76,13 +84,17 @@ function getEDS(manifest) {
     return;
   }
   
-  const services = manifest.service;
+  let services = manifest.service;
 
   if (!Array.isArray(services)) {
     services = [services];
   }
 
-  return services.find(service => service?.profile === _EDS_PROFILE_URL);
+  const match = services.find(service => service?.profile === _EDS_PROFILE_URL);
+
+  if (match) {
+    return match['@id'];
+  }
 }
 
 /**

--- a/src/plugins/jh-annotation-fetch-plugin/JHAnnotationFetcher.js
+++ b/src/plugins/jh-annotation-fetch-plugin/JHAnnotationFetcher.js
@@ -10,9 +10,9 @@ export default class JHAnnotationFetcher extends Component {
   }
 
   fetchAnnotations() {
-    const { canvases, receiveAnnotation } = this.props;
+    const { canvases, manifest, receiveAnnotation } = this.props;
     getRosaWebAnnotations(canvases, receiveAnnotation);
-    getEldarionAnnotations(canvases, receiveAnnotation);
+    getEldarionAnnotations(canvases, receiveAnnotation, manifest);
   }
 
   componentDidMount() {


### PR DESCRIPTION
Has the same functionality as before, but no longer tries to guess at the URL of the discovery service. Instead, it simply does nothing if no such service is found on the manifest